### PR TITLE
AI - Improvement: Check Unit Inventory for package type Item

### DIFF
--- a/addons/ai/XEH/cba_settings_cigsOnAi.inc.sqf
+++ b/addons/ai/XEH/cba_settings_cigsOnAi.inc.sqf
@@ -31,7 +31,7 @@
 	SETLSTRING(cigsonai_delay),
 											//    _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
 	[LSTRING(set_mainCat_ai), LSTRING(set_subCat_cigsonai)],				//    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
-	[1,120,5,0, false],					//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
+	[5,120,5,0, false],					//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
 	1,										//    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <NUMBER>
 	{},										//    _script      - Script to execute when setting is changed. (optional) <CODE>
 	false									//    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>

--- a/addons/ai/XEH/cba_settings_dynamicSmoking.inc.sqf
+++ b/addons/ai/XEH/cba_settings_dynamicSmoking.inc.sqf
@@ -9,7 +9,7 @@
 	[LSTRING(set_mainCat_ai), LSTRING(set_subCat_dynamicAiSmoking)],			//    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
 	true,																		//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
 	1,																			//    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <NUMBER>
-	FUNC(loop_start),														//    _script      - Script to execute when setting is changed. (optional) <CODE>
+	FUNC(loop_start),															//    _script      - Script to execute when setting is changed. (optional) <CODE>
 	true																		//    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
 ] call CBA_fnc_addSetting;
 
@@ -47,6 +47,19 @@
 																				//    _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
 	[LSTRING(set_mainCat_ai), LSTRING(set_subCat_dynamicAiSmoking)],			//    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
 	[ 5, 60, 15, 0 ],															//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
+	1,																			//    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <NUMBER>
+	{},																			//    _script      - Script to execute when setting is changed. (optional) <CODE>
+	false																		//    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
+] call CBA_fnc_addSetting;
+
+
+[
+	QSET(dynamicSmoking_checkUnitInventory),												//    _setting     - Unique setting name. Matches resulting variable name <STRING>
+	"CHECKBOX",																	//    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
+	SETLSTRING(dynamicSmoking_checkUnitInventory),
+																				//    _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
+	[LSTRING(set_mainCat_ai), LSTRING(set_subCat_dynamicAiSmoking)],			//    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
+	true,																		//    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
 	1,																			//    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <NUMBER>
 	{},																			//    _script      - Script to execute when setting is changed. (optional) <CODE>
 	false																		//    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>

--- a/addons/ai/functions/cigs_on_ai/fn_processQueue.sqf
+++ b/addons/ai/functions/cigs_on_ai/fn_processQueue.sqf
@@ -19,9 +19,16 @@ params ["_unit"];
 
 if ( isNull _unit || { _unit call EFUNC(core,isPlayer) } ) exitWith {};
 
+// Statements
+private _addCigsOnAi = { [FUNC(addCigItemsToUnit), [_unit], SET(cigsonai_delay)] call CBA_fnc_waitAndExecute; };
+private _addToDynamicAI = { _unit call FUNC(addUnitToFramework); };
+
+// Conditions
+private _checkUnitInventory =  { SET(dynamicSmoking_checkUnitInventory) && { [_unit] call FUNC(canTakeFromPack) } };
+private _checkCigsOnAiChance = { SET(cigsonai_enable)                   && { random 1 < SET(cigsonai_chance)    } };
 
 
-if ( !SET(cigsonai_enable) ) exitWith {};
-if ( random 1 < SET(cigsonai_chance) ) then { [FUNC(addCigItemsToUnit), [_unit], SET(cigsonai_delay) max 5] call CBA_fnc_waitAndExecute; };
-
-
+switch (true) do {
+    case ( call _checkUnitInventory  ): _addToDynamicAI;
+    case ( call _checkCigsOnAiChance ): _addCigsOnAi;
+};

--- a/addons/ai/functions/dynamicSmoking/fn_startConsuming.sqf
+++ b/addons/ai/functions/dynamicSmoking/fn_startConsuming.sqf
@@ -31,16 +31,11 @@ private _curHMD = hmd _unit;
 
 if (isNil "_slot") then { _slot = SET(dynamicSmoking_slot) };
 
-// TODO: Investigate unit not getting their facewear removed!!
-
-// [slot, needsRemoval]
 switch (true) do {
     case (_curGlasses isEqualTo ""): { ["GOGGLES", false] };
     case (_curHMD     isEqualTo ""): { ["HMD", false] };
     default { [_slot, true] };
 } params ["_targetSlot", "_needsRemoval"];
-
-
 
 
 // If setting is to not remove any item but it the targetslot is blocked, exit

--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -61,6 +61,12 @@
         <Key ID="STR_cigs_ai_set_dynamicSmoking_enable_desc">
             <English>Enables the system to dynamically make AI smoke cigarettes.\nRequires Cigs on AI to be enabled to distribute items and add to the framework.</English>
         </Key>
+        <Key ID="STR_cigs_ai_set_dynamicSmoking_checkUnitInventory">
+            <English>Check Unit for compatible Items</English>
+        </Key>
+        <Key ID="STR_cigs_ai_set_dynamicSmoking_checkUnitInventory_desc">
+            <English>When enabled, it will check if a unit has a package - both smokable or suckable. If so, these units will be added to the framework.</English>
+        </Key>
         <Key ID="STR_cigs_ai_set_dynamicSmoking_slot_remove">
             <English>Remove Slot Item</English>
         </Key>


### PR DESCRIPTION
AI Units with a Package of Suckable or Smokable Items will get added to the Dynamic Smoking Framework.

This will not check if a unit has a lighter if they have a smokable package.