### PR TITLE
Translations - Improved Japanese Translations, Added Stringtables for Sucking

### DIFF
--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -73,7 +73,7 @@
         <Key ID="STR_cigs_ai_set_dynamicSmoking_checkUnitInventory">
             <English>Check Unit for compatible Items</English>
             <French>Vérifiez l'unité pour les articles compatibles</French>
-            <Japanese>互換性のあるアイテムについては、ユニットを確認してください。</Japanese>
+            <Japanese>ユニットの互換アイテムを確認する</Japanese>
         </Key>
         <Key ID="STR_cigs_ai_set_dynamicSmoking_checkUnitInventory_desc">
             <English>When enabled, it will check if a unit has a package - both smokable or suckable. If so, these units will be added to the framework.</English>

--- a/addons/core/functions/fn_cba_contextMenu.sqf
+++ b/addons/core/functions/fn_cba_contextMenu.sqf
@@ -109,7 +109,7 @@
 [
     "#All"                      // item - Classname or itemType or wildcard
     ,["GOGGLES", "HMD"]         // Slots - STRING or ARRAY of Strings
-    ,[LLSTRING(sucking_start), "Requires a Lighter or Matches in your inventory"]    // Display Name - STRING or ARRAY of Strings - [displayName, Tooltip]
+    ,[LLSTRING(sucking_start), LLSTRING(sucking_start_desc)]    // Display Name - STRING or ARRAY of Strings - [displayName, Tooltip]
     ,[]                         // Text Color
     ,QPATHTOF(data\ui\pop_consume.paa)                // Icon path
     ,[                          // condition - CODE or ARRAY of Code [_conditionEnable, _conditionShow] - Arguments: params ["_unit", "_container", "_item", "_slot", "_params"];

--- a/addons/core/stringtable.xml
+++ b/addons/core/stringtable.xml
@@ -4,7 +4,7 @@
         <Key ID="STR_cigs_core_set_ace_arsenal_tab">
             <English>Enable Custom Category Tab in ACE Arsenal</English>
             <French>Activer les catégories personnalisées dans ACE Arsenal</French>
-            <Japanese>ACE武器庫でカスタムされたカテゴリ分類を有効化</Japanese>
+            <Japanese>ACE武器庫でカスタムされた分類を有効化</Japanese>
         </Key>
         <Key ID="STR_cigs_core_set_ace_arsenal_tab_desc">
             <English>When Enabled, this will create a Immersion Cig Tab in the ACE Arsenal (right side).\nThis can be enabled during the mission. To disable it, the mission needs to be restarted.</English>
@@ -321,7 +321,7 @@
             <English>Eat the thing, duh</English>
             <French>Manger la chose, bien sûr</French>
             <German>Du hast schon richtig gelesen</German>
-            <Japanese>そりゃあ、食べるってことだろ。</Japanese>
+            <Japanese>そりゃあ、食べるって意味だろ</Japanese>
         </Key>
         <Key ID="STR_cigs_core_pay_respect">
             <English>Pay Respect to the Fallen...</English>
@@ -378,6 +378,10 @@
             <German>Lutsch den Lutscher</German>
             <Japanese>吸い始める</Japanese>
             <Chinese>放進嘴巴含</Chinese>
+        </Key>
+        <Key ID="STR_cigs_core_sucking_start_desc">
+            <English>Licking whatever’s in your mouth</English>
+            <Japanese>口の中にあるものを何でも舐める</Japanese>
         </Key>
         <Key ID="STR_cigs_core_sucking_stop">
             <English>Stop Sucking</English>
@@ -441,7 +445,7 @@
             <English>Hmm, it tastes like %1!</English>
             <French>Hmm, ça a un goût de %1!</French>
             <German>Hmm, es schmeckt nach %1!</German>
-            <Japanese>うーん、これは%1味だ!</Japanese>
+            <Japanese>うーん、これは %1 みたいな味だ!</Japanese>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
The description for the "Start Sucking" context menu was missing, and the message "Requires a Lighter or Matches in your inventory" was used as a placeholder.
This commit adds the description about "sucking".

Also, some minor tweaks for Japanese localization.