### PR TITLE
API - Renamed API Event Keys

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -1,18 +1,19 @@
 # Readme for Mission and Mod Makers
 
 ## Public API Events
-| Event Key                     | Parameters                                      | Locality | Type   | Description        |
-| ----------------------------- | ----------------------------------------------- | -------- | ------ | ------------------ |
-| `cigs_core_api_takeFromPack`  | _unit, _class_cigpack, _item_glasses, _item_hmd | Local    | Listen | Sucking Loop       |
-| `cigs_core_api_useLighter`    | _unit, _className, _type                        | Local    | Listen | Using a Lighter    |
-| `cigs_core_api_eatCig`        | _unit, _item, _slot                             | Local    | Listen | Eating a Cigarette |
-| `cigs_core_API_startsSmoking` | _unit, _item, _slot                             | Local    | Listen | Starts Smoking     |
-| `cigs_core_api_smoking`       | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Smoking Loop       |
-| `cigs_core_API_stopsSmoking`  | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Stops Smoking      |
-| `cigs_core_API_startsSucking` | _unit, _item, _slot                             | Local    | Listen | Starts Sucking     |
-| `cigs_core_api_sucking`       | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Sucking Loop       |
-| `cigs_core_API_stopsSucking`  | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Stops Sucking      |
+| Event Key                | Parameters                                      | Locality | Type   | Description        |
+| ------------------------ | ----------------------------------------------- | -------- | ------ | ------------------ |
+| `cigs_api_takeFromPack`  | _unit, _class_cigpack, _item_glasses, _item_hmd | Local    | Listen | Sucking Loop       |
+| `cigs_api_useLighter`    | _unit, _className, _type                        | Local    | Listen | Using a Lighter    |
+| `cigs_api_eatCig`        | _unit, _item, _slot                             | Local    | Listen | Eating a Cigarette |
+| `cigs_api_startsSmoking` | _unit, _item, _slot                             | Local    | Listen | Starts Smoking     |
+| `cigs_api_smoking`       | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Smoking Loop       |
+| `cigs_api_stopsSmoking`  | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Stops Smoking      |
+| `cigs_api_startsSucking` | _unit, _item, _slot                             | Local    | Listen | Starts Sucking     |
+| `cigs_api_sucking`       | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Sucking Loop       |
+| `cigs_api_stopsSucking`  | _unit, _currentTime, _currentItem, _itemType    | Local    | Listen | Stops Sucking      |
 
+As of v3.0.7, API Event Keys have been renamed from `cigs_core_api` to `cigs_api`. 
 
 ## Unit Variable APIs
 The following APIs can be used by `_unit setVariable [_apiKey, _value, true];`.
@@ -20,7 +21,7 @@ Make sure to broadcast the variable as the checks will be on the individual clie
 
 | ApiKey                     | Values | Desc                                                 |
 | -------------------------- | ------ | ---------------------------------------------------- |
-| "cigs_api_blockAnimations" | true   | Will block all cigs related animations on said unit. |
+| `cigs_api_blockAnimations` | true   | Will block all cigs related animations on said unit. |
 
 
 ## Useful Functions

--- a/addons/ai/functions/dynamicSmoking/fn_canConsume.sqf
+++ b/addons/ai/functions/dynamicSmoking/fn_canConsume.sqf
@@ -29,7 +29,7 @@ params [ "_unit", ["_ignoreTime", false, [true]] ];
                 && {
                     combatBehaviour _unit in ["CARELESS", "SAFE", "AWARE"]
                     && {
-                        _unit isNil QGVAR(API_dynamicSmoking_blocked)
+                        _unit isNil QEGVAR(api,dynamicSmoking_blocked)
                         && {
                             !( _unit getVariable [QPVAR(isSmoking), false] ) && !( _unit getVariable [QPVAR(isSucking), false] )
                             && {

--- a/addons/ai/functions/dynamicSmoking/fn_cleanupArray_condition.sqf
+++ b/addons/ai/functions/dynamicSmoking/fn_cleanupArray_condition.sqf
@@ -19,7 +19,7 @@ params ["_unit"];
 
 alive _unit
 && {
-    _unit isNil QGVAR(API_dynamicSmoking_blocked)
+    _unit isNil QEGVAR(api,dynamicSmoking_blocked)
     && {
         _unit call EFUNC(core,canTakeFromPack)
     }

--- a/addons/core/functions/eat_cig/fn_addEatAction.sqf
+++ b/addons/core/functions/eat_cig/fn_addEatAction.sqf
@@ -48,7 +48,7 @@
             [_unit, 0.5 + random 0.5, "head", "burn", _unit] call ace_medical_fnc_addDamageToUnit;
         };
 
-        [QGVAR(api_eatCig),  [_unit, _item, _slot]] call CBA_fnc_localEvent;
+        [QEGVAR(api,eatCig),  [_unit, _item, _slot]] call CBA_fnc_localEvent;
     },
     true    // Consumes Item on Action
 ] call CBA_fnc_addItemContextMenuOption;

--- a/addons/core/functions/lighter/fn_useLighter.sqf
+++ b/addons/core/functions/lighter/fn_useLighter.sqf
@@ -16,16 +16,13 @@
 * Public: No
 */
 
-
-
-
 params [
     "_unit",
     ["_forced", false, [true]],
     [ "_mode", "NORMAL", [""] ]
 ];
 
-if !(_mode in ["NORMAL", "GIVING", "RECIEVING"]) exitWith { systemChat "Someone Fucked Up!"}; 
+if !(_mode in ["NORMAL", "GIVING", "RECIEVING"]) exitWith { systemChat "Someone Fucked Up!" }; 
 
 [ _unit ] call FUNC(getLighter) params [ "_lighterClass", "_lighterType" ];
 
@@ -40,9 +37,6 @@ switch (true) do {
     case (_mode isEqualTo "GIVING"): { [ _unit, "PutDown",           1.5 ] call FUNC(anim); };
     default                          { [ _unit, QEGVAR(anim,cig_in), 3.0 ] call FUNC(anim); };
 };
-
-
-
 
 if (_mode isNotEqualTo "GIVING") then {
     // Sound Effect
@@ -60,4 +54,4 @@ if (_mode isNotEqualTo "GIVING") then {
 [ CBA_fnc_serverEvent , [ QGVAR(EH_useLighter_combustion), [_unit] ], 1.5 ] call CBA_fnc_waitAndExecute;
 
 // API Event
-[ QGVAR(API_useLighter),  [ _unit, _lighterClass, _lighterType, _mode ] ] call CBA_fnc_localEvent;
+[ QEGVAR(api,useLighter),  [ _unit, _lighterClass, _lighterType, _mode ] ] call CBA_fnc_localEvent;

--- a/addons/core/functions/pack/fn_takeFromPack.sqf
+++ b/addons/core/functions/pack/fn_takeFromPack.sqf
@@ -41,4 +41,4 @@ switch (true) do {
 };
 
 
-[QGVAR(API_takeFromPack), [_unit,_class_cigpack, _item_glasses, _item_hmd]] call CBA_fnc_localEvent;
+[QEGVAR(api,takeFromPack), [_unit,_class_cigpack, _item_glasses, _item_hmd]] call CBA_fnc_localEvent;

--- a/addons/core/functions/smoking/fn_smoking.sqf
+++ b/addons/core/functions/smoking/fn_smoking.sqf
@@ -182,4 +182,4 @@ private  _delay = (20 + ceil random 10) / SET(smoking_frequency);
 ////////////////////////////////////////
 // API 
 ////////////////////////////////////////
-[QGVAR(API_smoking),  [_unit, _smokeData]] call CBA_fnc_localEvent;
+[QEGVAR(api,smoking),  [_unit, _smokeData]] call CBA_fnc_localEvent;

--- a/addons/core/functions/smoking/fn_smoking_start.sqf
+++ b/addons/core/functions/smoking/fn_smoking_start.sqf
@@ -119,4 +119,4 @@ if (!isNil "_flavor") then { [ { [QGVAR(EH_notify), format [LLSTRING(taste_flavo
 ////////////////////////////////////////
 // API
 ////////////////////////////////////////
-[QGVAR(API_startsSmoking), [_unit, _smokeData]] call CBA_fnc_localEvent;
+[QEGVAR(api,startsSmoking), [_unit, _smokeData]] call CBA_fnc_localEvent;

--- a/addons/core/functions/smoking/fn_smoking_stop.sqf
+++ b/addons/core/functions/smoking/fn_smoking_stop.sqf
@@ -52,4 +52,4 @@ private _vanish = switch (true) do {
 ////////////////////////////////////////
 // API
 ////////////////////////////////////////
-[QGVAR(API_stopsSmoking), [_unit, _smokeData]] call CBA_fnc_localEvent;
+[QEGVAR(api,stopsSmoking), [_unit, _smokeData]] call CBA_fnc_localEvent;

--- a/addons/core/functions/sucking/fn_sucking.sqf
+++ b/addons/core/functions/sucking/fn_sucking.sqf
@@ -149,4 +149,4 @@ private  _delay = 10 + random 20;
 ////////////////////////////////////////
 // API 
 ////////////////////////////////////////
-[QGVAR(API_sucking),  [_unit, _suckData]] call CBA_fnc_localEvent;
+[QEGVAR(api,sucking),  [_unit, _suckData]] call CBA_fnc_localEvent;

--- a/addons/core/functions/sucking/fn_sucking_start.sqf
+++ b/addons/core/functions/sucking/fn_sucking_start.sqf
@@ -125,4 +125,4 @@ _unit call FUNC(add_slotItemChanged_EH);
 ////////////////////////////////////////
 // API
 ////////////////////////////////////////
-[QGVAR(API_startsSucking), [_unit, _suckData]] call CBA_fnc_localEvent;
+[QEGVAR(api,startsSucking), [_unit, _suckData]] call CBA_fnc_localEvent;

--- a/addons/core/functions/sucking/fn_sucking_stop.sqf
+++ b/addons/core/functions/sucking/fn_sucking_stop.sqf
@@ -30,4 +30,4 @@ if (_suckData get "curSucks" > _suckData get "totalSucks") then {
 ////////////////////////////////////////
 // API
 ////////////////////////////////////////
-[QGVAR(API_stopsSucking), [_unit, _suckData]] call CBA_fnc_localEvent;
+[QEGVAR(api,stopsSucking), [_unit, _suckData]] call CBA_fnc_localEvent;


### PR DESCRIPTION
Renamed the ugly `cigs_core_api_...` keys to `cigs_api`