### PR TITLE
Core - Improvement: force update of Inventory UI

### DIFF
--- a/addons/core/functions/misc/fn_cba_contextMenu.sqf
+++ b/addons/core/functions/misc/fn_cba_contextMenu.sqf
@@ -36,6 +36,7 @@
     {                          // statement - CODE - Arguments: params ["_unit", "_container", "_item", "_slot", "_params"];
         params ["_unit", "_container", "_item", "_slot", "_params"];
         [_unit, _item, _slot] call FUNC(takeFromPack);
+        _unit action ["Gear", objNull];
         false
     }
 ] call CBA_fnc_addItemContextMenuOption;

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 #define MAJOR 2
 #define MINOR 9
 #define PATCH 9
-#define BUILD 645
+#define BUILD 647
 
 
 // #define VERSION MACROS

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 #define MAJOR 2
 #define MINOR 9
 #define PATCH 9
-#define BUILD 647
+#define BUILD 648
 
 
 // #define VERSION MACROS


### PR DESCRIPTION
Reopens the inventory to force update of inventory UI when taking an item from a cigarettepack or alike wih the cba context menu action.